### PR TITLE
Recaptcha2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ fiches/media/images/site/map/acc.css
 fiches/media/images/site/map/index.html
 *.bak
 ICONS
+src/

--- a/fiches/forms.py
+++ b/fiches/forms.py
@@ -1,6 +1,7 @@
 from django.forms import ModelForm
 from django import forms
-from captcha.fields import ReCaptchaField
+from snowpenguin.django.recaptcha2.fields import ReCaptchaField
+from snowpenguin.django.recaptcha2.widgets import ReCaptchaWidget
 from fiches.models import *
 
 
@@ -16,7 +17,7 @@ class UserProfileForm(ModelForm):
 
 class AllauthSignupForm(forms.Form):
 
-    captcha = ReCaptchaField()
+    captcha = ReCaptchaField(widget=ReCaptchaWidget())
 
     def signup(self, request, user):
         """ Required, or else it throws deprecation warnings """

--- a/fiches/templates/account/signup.html
+++ b/fiches/templates/account/signup.html
@@ -1,9 +1,10 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
+{% load recaptcha2 %}
 
 {% block title %}{% trans "Signup" %}{% endblock %}
-{% block page-title %}{% trans "Signup" %}{% endblock %}
+{% block page-title %}{% trans "Signup" %}{% recaptcha_init %}{% endblock %}
 
 {% block content %}
 
@@ -12,8 +13,7 @@
 <form class="signup account" id="signup_form" method="post" action="{% url 'account_signup' %}">
   {% csrf_token %}
   {{ form.as_p }}
-  {{ form.captcha }}
-  {{ form.captcha.errors }}
+
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}

--- a/firp/settings.py
+++ b/firp/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = (
     'allauth.account',
     'allauth.socialaccount',
     'stopforumspam',
-    'captcha',
+    'snowpenguin.django.recaptcha2',
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
Following google mail


Dear Webmaster,
--
You  are receiving this email because you are registered as a website  administrator using reCAPTCHA, and your website is still using reCAPTCHA  v1, which will be turned off on March 31, 2018.
We  announced the reCAPTCHA v1 deprecation in May 2016. Starting in  November 2017, a small percentage of reCAPTCHA v1 traffic will begin to  show a notice informing users that the old API will soon be retired. Any  calls to the v1 API will not work after March 31, 2018.
To ensure continued functionality, you’ll need to update your website to a current version of reCAPTCHA. You can learn more about reCAPTCHA v2, Invisible reCAPTCHA and reCAPTCHA Android API in our Developer’s Guide.  The new APIs are simple to implement and will streamline the captcha  experience for your users. If you need help, you can engage in the reCAPTCHA Google Developer Group or post to Stack Overflow with the ‘recaptcha’ tag.
We hope that your upgrade will be seamless, and we’re confident you’ll be happy with the results.
Thank you,
reCAPTCHA Support

