### PR TITLE
Update Django to 1.11

### DIFF
--- a/fiches/models.py
+++ b/fiches/models.py
@@ -224,7 +224,8 @@ class Fiche(models.Model):
                               default='images/site/no-image.png')
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
-                                 related_name='fiches')
+                                 related_name='fiches',
+                                 on_delete=models.CASCADE)
     pseudo_du_personnage = models.CharField(max_length=30,
                                             default="?")
     main_dir = models.CharField(max_length=1,
@@ -257,15 +258,18 @@ class Fiche(models.Model):
     inventaire_fdg = models.OneToOneField('Inventaire',
                                           blank=True,
                                           null=True,
-                                          related_name='proprietaire')
+                                          related_name='proprietaire',
+                                          on_delete=models.SET_NULL)
     equipement = models.OneToOneField('Equipement',
                                       blank=True,
                                       null=True,
-                                      related_name='proprietaire')
+                                      related_name='proprietaire',
+                                      on_delete=models.SET_NULL)
     bourse = models.OneToOneField('Bourse',
                                   blank=True,
                                   null=True,
-                                  related_name='proprietaire')
+                                  related_name='proprietaire',
+                                  on_delete=models.SET_NULL)
 
     class Meta:
         ordering = ["nom", "prenom"]
@@ -294,7 +298,8 @@ class Fiche(models.Model):
 class UserProfile(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL,
                                 null=True,
-                                related_name='infos')
+                                related_name='infos',
+                                on_delete=models.CASCADE)
     image = models.ImageField(upload_to='images/users',
                               default='images/site/no-image.png')
     naissance = models.DateField(blank=True,
@@ -330,7 +335,8 @@ class Objet(models.Model):
     #                           default='images/site/WoWUnknownItem01.PNG')
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
-                                 related_name='objet')
+                                 related_name='objet',
+                                 on_delete=models.SET_NULL)
     image_url = models.CharField(max_length=50,
                                  default='WoWUnknownItem01')
 
@@ -352,7 +358,8 @@ class Objet(models.Model):
 class Armure(models.Model):
     objet = models.OneToOneField(Objet,
                                  null=True,
-                                 related_name='armure')
+                                 related_name='armure',
+                                 on_delete=models.CASCADE)
     effet = models.CharField(max_length=400,
                              default='Aucun')
     effet_ig = models.CharField(max_length=400,
@@ -384,10 +391,12 @@ class Case(models.Model):
                                max_value=99)
     objet = models.ForeignKey(Objet,
                               null=True,
-                              related_name='case')
+                              related_name='case',
+                              on_delete=models.CASCADE)
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
-                                 related_name='cases')
+                                 related_name='cases',
+                                 on_delete=models.CASCADE)
 
     class Meta:
         ordering = ["objet", "nombre"]
@@ -563,7 +572,8 @@ class Enchantement(models.Model):
                                       default=5)
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
-                                 related_name='enchantement')
+                                 related_name='enchantement',
+                                 on_delete=models.SET_NULL)
 
     def __unicode__(self):
         return u'%s' % (self.nom)
@@ -606,11 +616,13 @@ class Quete(models.Model):
     reservee = models.ForeignKey(Fiche,
                                  blank=True,
                                  null=True,
-                                 related_name='quete_reservee')
+                                 related_name='quete_reservee',
+                                 on_delete=models.SET_NULL)
     leader = models.ForeignKey(Fiche,
                                null=True,
                                blank=True,
-                               related_name='quete_reussie')
+                               related_name='quete_reussie',
+                               on_delete=models.SET_NULL)
     ennemi = models.CharField(max_length=60,
                               default='images/site/quest/Portraits/FollowerPortrait_NoPortrait.png')
     creation = models.DateField(default=timezone.now)
@@ -634,7 +646,8 @@ class Operation(models.Model):
     dirigeant = models.ForeignKey(Fiche,
                                   null=True,
                                   blank=True,
-                                  related_name='dirigeant_op')
+                                  related_name='dirigeant_op',
+                                  on_delete=models.SET_NULL)
 
     class Meta:
         ordering = ["nom"]
@@ -650,15 +663,18 @@ class Mission(models.Model):
     operation = models.ForeignKey(Operation,
                                   null=True,
                                   blank=True,
-                                  related_name='mission')
+                                  related_name='mission',
+                                  on_delete=models.SET_NULL)
     dirigeant = models.ForeignKey(Fiche,
                                   null=True,
                                   blank=True,
-                                  related_name='dirigeant_mission')
+                                  related_name='dirigeant_mission',
+                                  on_delete=models.SET_NULL)
     autre_dirigeant = models.ForeignKey(Fiche,
                                         null=True,
                                         blank=True,
-                                        related_name='autre_dirigeant')
+                                        related_name='autre_dirigeant',
+                                        on_delete=models.SET_NULL)
     numero = models.SmallIntegerField(default=0)
     lieu = models.CharField(max_length=100)
     jour = IntegerRangeField(default='1', min_value=1,
@@ -740,7 +756,8 @@ class Sort(models.Model):
     classe = models.ForeignKey(Classe,
                                null=True,
                                blank=True,
-                               related_name='sort')
+                               related_name='sort',
+                               on_delete=models.SET_NULL)
     image_url = models.CharField(max_length=50,
                                  default='WoWUnknownItem01')
 
@@ -778,7 +795,8 @@ class Piece(models.Model):
     mobilier = models.CharField(max_length=500)
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
-                                 related_name='piece')
+                                 related_name='piece',
+                                 on_delete=models.SET_NULL)
     image = models.ImageField(upload_to='images/maisons',
                               default='images/site/no-image.png')
 
@@ -795,7 +813,8 @@ class Etage(models.Model):
                                     related_name='etage')
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
-                                 related_name='etage')
+                                 related_name='etage',
+                                 on_delete=models.SET_NULL)
 
     def __unicode__(self):
         return u'%s' % (self.nom)
@@ -850,7 +869,8 @@ class Maison(models.Model):
     proprietaire = models.ForeignKey(Fiche,
                                      blank=True,
                                      null=True,
-                                     related_name='maison')
+                                     related_name='maison',
+                                     on_delete=models.SET_NULL)
     image = models.ImageField(upload_to='images/maisons',
                               default='images/site/no-image.png')
 
@@ -879,7 +899,8 @@ class Legende(models.Model):
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
                                  related_name='legende',
-                                 related_query_name='legende')
+                                 related_query_name='legende',
+                                 on_delete=models.SET_NULL)
     description = models.CharField(max_length=6000,
                                    default='A venir')
     image = models.ImageField(upload_to='images/persos',
@@ -900,4 +921,5 @@ class Token(models.Model):
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
                                  related_name='token',
-                                 related_query_name='token')
+                                 related_query_name='token',
+                                 on_delete=models.CASCADE)

--- a/fiches/rpg/avant_garde/models.py
+++ b/fiches/rpg/avant_garde/models.py
@@ -164,7 +164,8 @@ class Avant_garde(models.Model):
                                       blank=True)
     createur = models.ForeignKey(settings.AUTH_USER_MODEL,
                                  null=True,
-                                 related_name='avant_garde')
+                                 related_name='avant_garde',
+                                 on_delete=models.CASCADE)
 
     class Meta:
         ordering = ["nom", "prenom"]
@@ -213,7 +214,8 @@ class Fantassin(models.Model):
                                           default=1)
     perso = models.OneToOneField(Avant_garde,
                                  null=True,
-                                 related_name='fantassin')
+                                 related_name='fantassin',
+                                 on_delete=models.CASCADE)
 
     def __unicode__(self):
         return u'%s, %s' % (self.perso.nom, 'fantassin')
@@ -249,7 +251,8 @@ class Apothicaire(models.Model):
                                           default=1)
     perso = models.OneToOneField(Avant_garde,
                                  null=True,
-                                 related_name='apothicaire')
+                                 related_name='apothicaire',
+                                 on_delete=models.CASCADE)
 
     def __unicode__(self):
         return u'%s, %s' % (self.perso.nom, 'apothicaire')
@@ -272,7 +275,8 @@ class Arbaletrier(models.Model):
                                       max_value=100)
     perso = models.OneToOneField(Avant_garde,
                                  null=True,
-                                 related_name='arbaletrier')
+                                 related_name='arbaletrier',
+                                 on_delete=models.CASCADE)
 
     def __unicode__(self):
         return u'%s, %s' % (self.perso.nom, 'arbalétrier')
@@ -323,7 +327,8 @@ class Eclaireur(models.Model):
                                           default=1)
     perso = models.OneToOneField(Avant_garde,
                                  null=True,
-                                 related_name='eclaireur')
+                                 related_name='eclaireur',
+                                 on_delete=models.CASCADE)
 
     def __unicode__(self):
         return u'%s, %s' % (self.perso.nom, 'éclaireur')
@@ -362,7 +367,8 @@ class Sorcier(models.Model):
                                     max_value=100)
     perso = models.OneToOneField(Avant_garde,
                                  null=True,
-                                 related_name='sorcier')
+                                 related_name='sorcier',
+                                 on_delete=models.CASCADE)
 
     def __unicode__(self):
         return u'%s, %s' % (self.perso.nom, 'sorcier')
@@ -407,7 +413,8 @@ class Rabatteur(models.Model):
                                             default=1)
     perso = models.OneToOneField(Avant_garde,
                                  null=True,
-                                 related_name='rabatteur')
+                                 related_name='rabatteur',
+                                 on_delete=models.CASCADE)
 
     def __unicode__(self):
         return u'%s, %s' % (self.perso.nom, 'rabatteur')

--- a/firp/settings.py
+++ b/firp/settings.py
@@ -8,9 +8,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
-import logging
-logger = logging.getLogger(__name__)
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -55,7 +52,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'stopforumspam.middleware.StopForumSpamMiddleware',
@@ -204,4 +200,4 @@ ACCOUNT_SIGNUP_FORM_CLASS = 'fiches.forms.AllauthSignupForm'
 if os.path.isfile("settings_local.py"):
     from settings_local import *
 else:
-    logger.warning("Warning: no settings_local.py")
+    print("Warning: no settings_local.py")

--- a/firp/urls.py
+++ b/firp/urls.py
@@ -6,7 +6,7 @@ from fiches import views
 
 urlpatterns = [
     # General
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^accounts/', include('allauth.urls')),
     url(r'^conseils/$', views.conseils, name='conseils'),
     url(r'^en-savoir-plus/$', views.plus, name='plus'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.8
+django==1.11
 django-autocomplete-light>=3.2.0
 django-allauth==0.32.0
 stopforumspam==1.8


### PR DESCRIPTION
And take care of most deprecated warnings for 2.0.

The stopforumspam middleware is holding the migration to 2.0, since it
does not follow the new middleware API.

Closes #18.